### PR TITLE
fix build script (edoc)

### DIFF
--- a/support/include.mk
+++ b/support/include.mk
@@ -43,6 +43,6 @@ $(EBIN_DIR)/%.$(EMULATOR): %.erl
 	$(ERLC) $(ERLC_FLAGS) -o . $<
 
 $(DOC_DIR)/%.html: %.erl
-	$(ERL) -noshell -run edoc file $< -run init stop
+	$(ERL) -noshell -run edoc files $< -run init stop
 	@mkdir -p $(DOC_DIR)
 	mv *.html $(DOC_DIR)


### PR DESCRIPTION
Building was broken in R17:

```
make[1]: Leaving directory '/home/clonejo/code/mpdlog/deps/lager'
make[1]: Entering directory '/home/clonejo/code/mpdlog/deps/erlmpd'
(cd src;make)
make[2]: Entering directory '/home/clonejo/code/mpdlog/deps/erlmpd/src'
erl -noshell -run edoc file erlmpd.erl -run init stop
{"init terminating in do_boot",error}
```

`edoc:file/1` is deprecated anyway, switching to `edoc:files/1` fixes the problem.
