### PR TITLE
Modernization, Sticker Support, Advanced `find` functions...

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,2 @@
+{erl_opts, [debug_info]}.
+{deps, []}.

--- a/src/erlmpd.app.src
+++ b/src/erlmpd.app.src
@@ -1,0 +1,13 @@
+{application, erlmpd,
+ [{description, "A simple client library for communicating with MPD"},
+  {vsn, "1.0.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+  {licenses, ["GPL-3.0+"]},
+  {links, []}
+ ]}.

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -34,7 +34,7 @@
 %% The music database
 -export([count/2, count/3, count_group/3, find/2, find/3, list/2, list/3,
          listall/1, listall/2, listallinfo/1, listallinfo/2,
-         lsinfo/1, lsinfo/2, search/3, update/1, update/2]).
+         lsinfo/1, lsinfo/2, search/3, search/2, update/1, update/2]).
 
 %% Stickers
 -export([sticker_delete/3, sticker_delete/4, sticker_list/3, sticker_get/4,
@@ -1176,6 +1176,16 @@ lsinfo(C=#mpd_conn{}, Uri) ->
 						list() | {error, any_error()}.
 search(C=#mpd_conn{}, Tag, What) ->
     parse_songs(command(C, "search", [atom_to_list(Tag), What])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Searches songs in the db that match the given filter
+%% It is similar to find/2, but case-insensitive.
+%% @end
+%%-------------------------------------------------------------------
+-spec search(C::mpd_conn(), Filter::filter()) -> list() | {error, any_error()}.
+search(C, Filter) ->
+    parse_songs(command(C, "search", [ex_parse(Filter)])).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1618,12 +1618,12 @@ ex_parse_inner({land, Exprlist})            -> ex_and([ex_parse_inner(Ex) ||
 
 ex_tagop(Tag, OP, Value) ->
     ["(", atom_to_list(Tag), case OP of
-        eq          -> "==";
-        ne          -> "!=";
-        contains    -> "contains";
-        starts_with -> "starts_with";
-        match       -> "=~";
-        mismatch    -> "!~"
+        eq          -> " == ";
+        ne          -> " != ";
+        contains    -> " contains ";
+        starts_with -> " starts_with ";
+        match       -> " =~ ";
+        mismatch    -> " !~ "
     end, ex_quote(Value), ")"].
 
 ex_quote(Value) ->

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -831,8 +831,7 @@ plchanges(C=#mpd_conn{}, Ver) ->
 -spec plchangesposid(C::mpd_conn(), Ver::integer()) ->
 						list() | {error, any_error()}.
 plchangesposid(C=#mpd_conn{}, Ver) ->
-    parse_changes(
-        command(C, "plchangesposid", [integer_to_list(Ver)])).
+    parse_group([cpos], command(C, "plchangesposid", [integer_to_list(Ver)])).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -919,7 +918,7 @@ listplaylistinfo(C=#mpd_conn{}, Name) ->
 %%-------------------------------------------------------------------
 -spec listplaylists(C::mpd_conn()) -> list() | {error, any_error()}.
 listplaylists(C=#mpd_conn{}) ->
-    parse_playlists(command(C, "listplaylists")).
+    parse_group([playlist], command(C, "listplaylists")).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -1462,12 +1461,6 @@ parse_stickers_line(Line) ->
     end).
 
 parse_song(List) -> convert_song(parse_pairs(List)).
-
-parse_changes(List) ->
-    pass_errors(List, fun(L) -> parse_group([cpos], L) end).
-
-parse_playlists(List) ->
-    pass_errors(List, fun(L) -> parse_group([playlist], L) end).
 
 parse_database(List) ->
     pass_errors(List, fun(L) ->

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1046,8 +1046,10 @@ sticker(C=#mpd_conn{}, find, Type, Uri, Name) ->
 sticker(C=#mpd_conn{}, delete, Type, Uri, Name) ->
         command(C, "sticker delete", [Type, Uri, Name]).
 
+-spec sticker(C::mpd_conn(), set, Type::string(), Uri::string(), Name::string(),
+				Value::string()) -> ok | {error, any_error()}.
 sticker(C=#mpd_conn{}, set, Type, Uri, Name, Value) ->
-        command(C, "sticker set", [Type, Uri, Name, Value]).
+        parse_none(command(C, "sticker set", [Type, Uri, Name, Value])).
 
 
 %%===================================================================

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -48,7 +48,7 @@
          moveoutput/2]).
 
 %% Audio output devices
--export([disableoutput/2, enableoutput/2, outputs/1]).
+-export([disableoutput/2, enableoutput/2, toggleoutput/2, outputs/1]).
 
 %% Reflection
 -export([commands/1, notcommands/1, tagtypes/1, urlhandlers/1]).
@@ -1399,6 +1399,16 @@ disableoutput(C=#mpd_conn{}, OutputId) ->
 						ok | {error, any_error()}.
 enableoutput(C=#mpd_conn{}, OutputId) ->
     parse_none(command(C, "enableoutput", [integer_to_list(OutputId)])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Toggles output with id OutputId
+%% @end
+%%-------------------------------------------------------------------
+-spec toggleoutput(C::mpd_conn(), OutputId::integer()) ->
+						ok | {error, any_error()}.
+toggleoutput(C=#mpd_conn{}, OutputId) ->
+    parse_none(command(C, "toggleoutput", [integer_to_list(OutputId)])).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -4,7 +4,8 @@
 -include("erlmpd.hrl").
 
 %% Exported functions not part of the MPD API
--export([connect/0, connect/2, connect/3, command/2, command/3, command/4,
+-export([connect/0, connect/2, connect/3, disconnect/1,
+         command/2, command/3, command/4,
          commandlist/3, commandlist/2, version/1]).
 
 %% Querying MPD's status
@@ -116,6 +117,10 @@ connect(Addr, Port, Pass) ->
             end;
         X -> X
     end.
+
+-spec disconnect(C::mpd_conn()) -> ok.
+disconnect(C) ->
+    gen_tcp:close(C#mpd_conn.port).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -976,9 +976,9 @@ count(C=#mpd_conn{}, Tag, X) ->
 %% Example: erlmpd:count_group(Conn, artist, {base, ""}).
 %% returns a list like this:
 %% [
-%% 	[{'Artist',<<"Ace Of Base">>},{songs,13},{playtime,2944}],
-%% 	[{'Artist',<<"Adele">>},{songs,1},{playtime,286}],
-%% 	[{'Artist',<<"Alan Silvestri">>},{songs,1},{playtime,164}]
+%% 	[{'Artist',&lt;&lt;"Ace Of Base"&gt;&gt;},{songs,13},{playtime,2944}],
+%% 	[{'Artist',&lt;&lt;"Adele"&gt;&gt;},{songs,1},{playtime,286}],
+%% 	[{'Artist',&lt;&lt;"Alan Silvestri"&gt;&gt;},{songs,1},{playtime,164}]
 %% ]
 %% @end
 %%-------------------------------------------------------------------

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -43,6 +43,10 @@
 %% Connection settings
 -export([close/1, kill/1, password/2, ping/1]).
 
+%% Partition commands
+-export([partition/2, listpartitions/1, newpartition/2, delpartition/2,
+         moveoutput/2]).
+
 %% Audio output devices
 -export([disableoutput/2, enableoutput/2, outputs/1]).
 
@@ -1302,6 +1306,61 @@ password(C=#mpd_conn{}, Password) ->
 ping(C=#mpd_conn{}) ->
     parse_none(command(C, "ping")).
 
+%%===================================================================
+%% Partition commands
+%%===================================================================
+%%-------------------------------------------------------------------
+%% @doc
+%% Switch the client to a different partition.
+%% @end
+%%-------------------------------------------------------------------
+-spec partition(C::mpd_conn(), Name::string()) -> ok | {error, any_error()}.
+partition(C=#mpd_conn{}, Name) ->
+    parse_none(command(C, "partition", [Name])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Query the list of partitions. Returns a list of proplists each of
+%% which at least contain property partition to identify the name
+%% of the partition. Other properties may exist to contain
+%% information about the partition (as per the MPD protocol spec).
+%%
+%% Example return value: [[{partition,<<"default">>}]]
+%% @end
+%%-------------------------------------------------------------------
+-spec listpartitions(C::mpd_conn()) -> [list()] | {error, any_error()}.
+listpartitions(C=#mpd_conn{}) ->
+    parse_group([partition], command(C, "listpartitions")).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Create a new partition.
+%% @end
+%%-------------------------------------------------------------------
+-spec newpartition(C::mpd_conn(), Name::string()) -> ok | {error, any_error()}.
+newpartition(C=#mpd_conn{}, Name) ->
+    parse_none(command(C, "newpartition", [Name])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Delete a partition. The partition must be empty
+%% (no connected clients and no associated outputs).
+%% @end
+%%-------------------------------------------------------------------
+-spec delpartition(C::mpd_conn(), Name::string()) -> ok | {error, any_error()}.
+delpartition(C=#mpd_conn{}, Name) ->
+    parse_none(command(C, "delpartition", [Name])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Move an output to the current partition.
+%% Unlike other output-control functions this one takes the name of
+%% the output rather than the ID.
+%% @end
+%%-------------------------------------------------------------------
+-spec moveoutput(C::mpd_conn(), Name::string()) -> ok | {error, any_error()}.
+moveoutput(C=#mpd_conn{}, Name) ->
+   parse_none(command(C, "moveoutput", [Name])).
 
 %%===================================================================
 %% Audio output devices

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -329,7 +329,12 @@ idle(C=#mpd_conn{}) -> idle(C, []).
 %% @end
 %%-------------------------------------------------------------------
 -spec noidle(C::mpd_conn()) -> ok | {error, network_error()}.
-noidle(C=#mpd_conn{}) -> command(C, "noidle").
+noidle(C=#mpd_conn{}) ->
+    % It is not permitted to do gen_tcp:recv here because this may be in
+    % progress already. When using `command()`, it often returns {ealready}
+    % but on rare occasions “succeeds” and runs into a timeout. Hence ignore
+    % any response by MPD (none is expected here).
+    gen_tcp:send(C#mpd_conn.port, format_command("noidle", [])).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -300,7 +300,7 @@ idle(C=#mpd_conn{}, Subsystems) ->
         true ->
             Subs = [atom_to_list(X) || X <- Subsystems],
             Resp = get_all(changed, command(C, "idle", Subs, infinity)),
-            [binary_to_atom(X) || X <- Resp];
+            pass_errors(Resp, fun(R) -> [binary_to_atom(X) || X <- R] end);
         false -> {error, mpd_version}
     end.
 

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -33,8 +33,8 @@
 -export([count/3, find/3, list/2, list/3, listall/1, listall/2, listallinfo/1,
          listallinfo/2, lsinfo/1, lsinfo/2, search/3, update/1, update/2]).
 
-%% Stickers (not currently working)
-%% -export([sticker/4, sticker/5, sticker/6]).
+%% Stickers
+-export([sticker/4, sticker/5, sticker/6]).
 
 %% Connection settings
 -export([close/1, kill/1, password/2, ping/1]).
@@ -979,22 +979,22 @@ update(C=#mpd_conn{}, Uri) ->
 
 
 %%===================================================================
-%% Stickers (not currently working)
+%% Stickers
 %%===================================================================
-%%sticker(C=#mpd_conn{}, delete, Type, Uri) ->
-%%        command(C, "sticker delete", [Type, Uri]);
-%%sticker(C=#mpd_conn{}, list, Type, Uri) ->
-%%        command(C, "sticker list", [Type, Uri]).
+sticker(C=#mpd_conn{}, delete, Type, Uri) ->
+        command(C, "sticker delete", [Type, Uri]);
+sticker(C=#mpd_conn{}, list, Type, Uri) ->
+        command(C, "sticker list", [Type, Uri]).
 
-%%sticker(C=#mpd_conn{}, get, Type, Uri, Name) ->
-%%        command(C, "sticker get", [Type, Uri, Name]);
-%%sticker(C=#mpd_conn{}, find, Type, Uri, Name) ->
-%%        command(C, "sticker find", [Type, Uri, Name]);
-%%sticker(C=#mpd_conn{}, delete, Type, Uri, Name) ->
-%%        command(C, "sticker delete", [Type, Uri, Name]).
+sticker(C=#mpd_conn{}, get, Type, Uri, Name) ->
+        command(C, "sticker get", [Type, Uri, Name]);
+sticker(C=#mpd_conn{}, find, Type, Uri, Name) ->
+        command(C, "sticker find", [Type, Uri, Name]);
+sticker(C=#mpd_conn{}, delete, Type, Uri, Name) ->
+        command(C, "sticker delete", [Type, Uri, Name]).
 
-%%sticker(C=#mpd_conn{}, set, Type, Uri, Name, Value) ->
-%%        command(C, "sticker set", [Type, Uri, Name, Value]).
+sticker(C=#mpd_conn{}, set, Type, Uri, Name, Value) ->
+        command(C, "sticker set", [Type, Uri, Name, Value]).
 
 
 %%===================================================================

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1170,13 +1170,8 @@ urlhandlers(C=#mpd_conn{}) ->
 %% Internal Functions
 %%===================================================================
 
-escape_quotes(X) -> escape_quotes(X, []).
-escape_quotes([H|T],S) ->
-    case H of
-        $" -> escape_quotes(T, S ++ ["\\\""]);
-        X  -> escape_quotes(T, S ++ [X])
-    end;
-escape_quotes([], X) -> X.
+escape_quotes(X) ->
+    string:replace(string:replace(X, "\\", "\\\\", all), "\"", "\\\"", all).
 
 receive_lines(Sock, Timeout) -> receive_lines(Sock, Timeout, []).
 receive_lines(Sock, Timeout, L) ->

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1325,7 +1325,7 @@ partition(C=#mpd_conn{}, Name) ->
 %% of the partition. Other properties may exist to contain
 %% information about the partition (as per the MPD protocol spec).
 %%
-%% Example return value: [[{partition,<<"default">>}]]
+%% Example return value: [[{partition,&lt;&lt;"default"&gt;&gt;}]]
 %% @end
 %%-------------------------------------------------------------------
 -spec listpartitions(C::mpd_conn()) -> [list()] | {error, any_error()}.

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -20,8 +20,8 @@
          seek/3, seekid/3, stop/1]).
 
 %% The current playlist
--export([add/2, addid/2, addid/3, clear/1, delete/2, deleteid/2,
-         deleteids/2, move/3, moveid/3, playlist/1, playlistfind/3,
+-export([add/2, addid/2, addid/3, addid_relative/3, clear/1, delete/2,
+         deleteid/2, deleteids/2, move/3, moveid/3, playlist/1, playlistfind/3,
          playlistid/1, playlistid/2, playlistinfo/1, playlistinfo/2,
          playlistsearch/3, plchanges/2, plchangesposid/2, shuffle/2,
          shuffle/1, swap/3, swapid/3]).
@@ -626,6 +626,21 @@ addid(C=#mpd_conn{}, Uri) ->
 addid(C=#mpd_conn{}, Uri, Pos) ->
     convert_to_integer(
         parse_value('Id', command(C, "addid", [Uri, integer_to_list(Pos)]))).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Like addid, but always interprets Pos as an offset relative
+%% to the currently playing song. Use Pos = 0 to add an entry right
+%% after the currently playing song.
+%% @end
+%%-------------------------------------------------------------------
+-spec addid_relative(C::mpd_conn(), Uri::string(), Pos::integer()) ->
+				integer() | binary() | {error, any_error()}.
+addid_relative(C=#mpd_conn{}, Uri, Pos) when Pos < 0 ->
+    addid(C, Uri, Pos);
+addid_relative(C=#mpd_conn{}, Uri, Pos) ->
+    convert_to_integer(parse_value('Id',
+        command(C, "addid", [Uri, io_lib:format("+~w", [Pos])]))).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -31,8 +31,9 @@
          rename/3, rm/2, save/2]).
 
 %% The music database
--export([count/3, find/3, list/2, list/3, listall/1, listall/2, listallinfo/1,
-         listallinfo/2, lsinfo/1, lsinfo/2, search/3, update/1, update/2]).
+-export([count/3, find/2, find/3, list/2, list/3,
+         listall/1, listall/2, listallinfo/1, listallinfo/2,
+         lsinfo/1, lsinfo/2, search/3, update/1, update/2]).
 
 %% Stickers
 -export([sticker/4, sticker/5, sticker/6]).
@@ -909,6 +910,10 @@ count(C=#mpd_conn{}, Tag, X) ->
 						list() | {error, any_error()}.
 find(C=#mpd_conn{}, Tag, X) ->
     parse_songs(command(C, "find", [atom_to_list(Tag), X])).
+
+-spec find(C::mpd_conn(), Query::string()) -> list() | {error, any_error()}.
+find(C, Query) ->
+    parse_songs(command(C, "find", [Query])).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1252,9 +1252,6 @@ convert_props(Map, Data) ->
             L, Map)
     end).
 
-binary_to_atom(Binary) ->
-    list_to_atom(binary_to_list(Binary)).
-
 convert_song(Data) ->
     convert_props([{integer, ['Id', 'Pos', 'Time', 'Track', 'Disc']}], Data).
 

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -32,7 +32,7 @@
          rename/3, rm/2, save/2]).
 
 %% The music database
--export([albumart/2, count/2, count/3, count_group/3, find/2, find/3,
+-export([albumart/2, count/2, count/3, count_group/3, find/2, find/3, find_ex/3,
 	list/2, list/3, listall/1, listall/2, listallinfo/1, listallinfo/2,
 	lsinfo/1, lsinfo/2, readpicture/2, search/3, search/2,
 	update/1, update/2]).
@@ -159,6 +159,15 @@
 %% returned. When a command accepts this type as input, the empty list []
 %% or a proplist with at most one sort and one window option can be provided
 %% to make use of this feature.
+
+-type sort_option()         :: {sort, tag() |
+				'-artist' | '-albumartist' | '-album' |
+				'-title' | '-track' | '-genre' | '-disc' |
+				'-date' |
+				albumartistsort | titlesort | composersort |
+				'-albumartistsort' | '-titlesort' |
+				'-composersort'}.
+%% A `-` prefix to a sort option causes the order of results to be inverted
 
 -type sticker_sort_option() :: {sort, uri | value | value_int}.
 
@@ -1138,6 +1147,19 @@ find(C=#mpd_conn{}, Tag, X) ->
 -spec find(C::mpd_conn(), Filter::filter()) -> list() | {error, any_error()}.
 find(C, Filter) ->
     parse_songs(command(C, "find", [ex_parse(Filter)])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Finds songs in the db that match the given filter optionally
+%% providing sort and window options.
+%% @end
+%%-------------------------------------------------------------------
+-spec find_ex(C::mpd_conn(), Filter::filter(),
+				Options::[window_option() | sort_option()]) ->
+				list() | {error, any_error()}.
+find_ex(C, Filter, Options) ->
+	parse_songs(command(C, "find", [ex_parse(Filter)], ?TIMEOUT,
+				sort_window_options_to_string(Options))).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -167,7 +167,7 @@
 				albumartistsort | titlesort | composersort |
 				'-albumartistsort' | '-titlesort' |
 				'-composersort'}.
-%% A `-` prefix to a sort option causes the order of results to be inverted
+%% A '-' prefix to a sort option causes the order of results to be inverted
 
 -type sticker_sort_option() :: {sort, uri | value | value_int}.
 

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -13,7 +13,8 @@
          noidle/1, idle_send/2, idle_receive/1, status/1, stats/1]).
 
 %% Playback options
--export([consume/2, crossfade/2, random/2, repeat/2, setvol/2, single/2]).
+-export([consume/2, crossfade/2, random/2, repeat/2, setvol/2, single/2,
+	volume/2]).
 
 %% Controlling playback
 -export([next/1, pause/2, play/1, play/2, playid/1, playid/2, previous/1,
@@ -548,6 +549,16 @@ single(C=#mpd_conn{}, State)  ->
         false -> {error, mpd_version}
     end.
 
+%%-------------------------------------------------------------------
+%% @doc
+%% Changes volume by relative amount (positive or negeative).
+%% The change is given in percent to be added to the current volume
+%% setting.
+%% @end
+%%-------------------------------------------------------------------
+-spec volume(C::mpd_conn(), Change::integer()) -> ok | {error, any_error()}.
+volume(C=#mpd_conn{}, Change) ->
+    parse_none(command(C, "volume", [integer_to_list(Change)])).
 
 %%===================================================================
 %% Controlling playback

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1335,8 +1335,10 @@ update(C=#mpd_conn{}, Uri) ->
 %% Delete all stickers associated to the given type and URI.
 %% @end
 %%-------------------------------------------------------------------
+-spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string()) ->
+						ok | {error, any_error()}.
 sticker_delete(C=#mpd_conn{}, Type, Uri) ->
-    command(C, "sticker delete", [Type, Uri]).
+    parse_none(command(C, "sticker delete", [Type, Uri])).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -1403,8 +1405,10 @@ sticker_find(C=#mpd_conn{}, Type, Uri, Name, Op, CompareValue, Options) ->
 %% Delete specific sticker by Type, URI and Name.
 %% @end
 %%-------------------------------------------------------------------
+-spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string(),
+				Name::string()) -> ok | {error, any_error()}.
 sticker_delete(C=#mpd_conn{}, Type, Uri, Name) ->
-    command(C, "sticker delete", [Type, Uri, Name]).
+    parse_none(command(C, "sticker delete", [Type, Uri, Name])).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1152,6 +1152,23 @@ find(C, Filter) ->
 %% @doc
 %% Finds songs in the db that match the given filter optionally
 %% providing sort and window options.
+%%
+%% Example returned list format:
+%%
+%% ```
+%% [ ... [{file,<<"album/zucchero_zu_co/01_13_the_flight.flac">>},
+%%       {'Last-Modified',<<"2024-03-03T20:57:24Z">>},
+%%       {'Added',<<"2024-08-23T20:33:10Z">>},
+%%       {'Format',<<"44100:16:2">>},
+%%       {'Album',<<"Zu & Co.">>},
+%%       {'Artist',<<"Zucchero">>},
+%%       {'Date',<<"2004">>},
+%%       {'Title',<<"The Flight">>},
+%%       {'Track',13},
+%%       {'Time',289},
+%%       {duration,<<"288.613">>}],
+%% ... ]
+%% '''
 %% @end
 %%-------------------------------------------------------------------
 -spec find_ex(C::mpd_conn(), Filter::filter(),
@@ -1562,6 +1579,13 @@ notcommands(C=#mpd_conn{}) ->
 %%-------------------------------------------------------------------
 %% @doc
 %% Shows a list of available song metadata.
+%%
+%% Example:
+%% ```
+%% {ok, Conn} = erlmpd:connect("127.0.0.1", 6600),
+%% T1 = erlmpd:tagtypes(Conn),
+%% io:fwrite("T1=<~p>~n", [T1]),
+%% '''
 %% @end
 %%-------------------------------------------------------------------
 -spec tagtypes(C::mpd_conn()) -> [binary()] | {error, any_error()}.

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -52,7 +52,8 @@
 -export([disableoutput/2, enableoutput/2, toggleoutput/2, outputs/1]).
 
 %% Reflection
--export([commands/1, notcommands/1, tagtypes/1, urlhandlers/1]).
+-export([commands/1, notcommands/1, tagtypes/1, tagtypes_disable/2,
+	tagtypes_enable/2, tagtypes_clear/1, tagtypes_all/1, urlhandlers/1]).
 
 %% Default timeout when waiting for a response from MPD
 -define(TIMEOUT, 5000).
@@ -1591,6 +1592,69 @@ notcommands(C=#mpd_conn{}) ->
 -spec tagtypes(C::mpd_conn()) -> [binary()] | {error, any_error()}.
 tagtypes(C=#mpd_conn{}) ->
     get_all(tagtype, command(C, "tagtypes")).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Disables selected tags from being returned to the client.
+%% Is expected that this function is only useful in special contexts
+%% such as designing an application which hides certain
+%% “uninteresting” tags but still displays new tags as they become
+%% supported by MPD.
+%%
+%% The “easy” approach to limit tagtypes is to call tagtypes_clear/1
+%% followed by tagtypes_enable/2.
+%% @end
+%%-------------------------------------------------------------------
+-spec tagtypes_disable(C::mpd_conn(), [tag()]) -> ok | {error, any_error()}.
+tagtypes_disable(C=#mpd_conn{}, Names) ->
+    parse_none(command(C, "tagtypes disable", [atom_to_list(T) || T <- Names])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Enables a selected subset of tags to be returned by subsequent
+%% queries.
+%%
+%% Example:
+%% ```
+%% ok = erlmpd:tagtypes_enable(Conn, [album, title]),
+%% T3 = erlmpd:tagtypes(Conn),
+%% io:fwrite("T3=<~p>~n", [T3]).
+%% '''
+%% @end
+%%-------------------------------------------------------------------
+-spec tagtypes_enable(C::mpd_conn(), [tag()]) -> ok | {error, any_error()}.
+tagtypes_enable(C=#mpd_conn{}, Names) ->
+    parse_none(command(C, "tagtypes enable", [atom_to_list(T) || T <- Names])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Clears all tag types. I.e. commands which may return song or
+%% album metadata return only the minimum amount of information.
+%%
+%% This can be used to limit the requested tags to the ones that the
+%% application is interested in by calling tagtypes_clear/1 followed
+%% by tagtypes_enable/2.
+%%
+%% Example:
+%% ```
+%% ok = erlmpd:tagtypes_clear(Conn),
+%% T2 = erlmpd:tagtypes(Conn),
+%% io:fwrite("T2=<~p>~n", [T2]),
+%% '''
+%% @end
+%%-------------------------------------------------------------------
+-spec tagtypes_clear(C::mpd_conn()) -> ok | {error, any_error()}.
+tagtypes_clear(C=#mpd_conn{}) ->
+    parse_none(command(C, "tagtypes clear")).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Enables all tag types. This is the inverse of tagtypes_clear/1.
+%% @end
+%%-------------------------------------------------------------------
+-spec tagtypes_all(C::mpd_conn()) -> ok | {error, any_error()}.
+tagtypes_all(C=#mpd_conn{}) ->
+    parse_none(command(C, "tagtypes all")).
 
 %%-------------------------------------------------------------------
 %% @doc

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -1107,7 +1107,7 @@ count(C=#mpd_conn{}, Tag, X) ->
 %% for all songs matching the given filter and groups by the given
 %% tag.
 %%
-%% Example: erlmpd:count_group(Conn, artist, {base, ""}).
+%% Example: `erlmpd:count_group(Conn, artist, {base, ""}).'
 %% returns a list like this:
 %% [
 %% 	[{'Artist',&lt;&lt;"Ace Of Base"&gt;&gt;},{songs,13},{playtime,2944}],

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -174,6 +174,14 @@
 
 -type sticker_sort_option() :: {sort, uri | value | value_int}.
 
+-type string_or_filter()    :: string() | filter().
+%% The meaning of the `Uri' parameter for stickers depends on the given `Type'.
+%% If `Type' is a `"song"' then `Uri' is of type string and specifies the file
+%% name (as a relative path starting at the top of the MPD structure) assigned
+%% to the sticker. If `Type' is `"filter"', `Uri' identifies a filter expression
+%% which erlmpd expects to receive as a filter specification of type `filter()'
+%% which erlmpd serializes before passing it to MPD.
+
 %%===================================================================
 %% Exported functions not part of the MPD API
 %%===================================================================
@@ -1347,31 +1355,33 @@ update(C=#mpd_conn{}, Uri) ->
 %% Delete all stickers associated to the given type and URI.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string()) ->
+-spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string_or_filter()) ->
 						ok | {error, any_error()}.
 sticker_delete(C=#mpd_conn{}, Type, Uri) ->
-    parse_none(command(C, "sticker delete", [Type, Uri])).
+    parse_none(command(C, "sticker delete", [Type, sticker_uri(Type, Uri)])).
 
 %%-------------------------------------------------------------------
 %% @doc
 %% Retrieve all stickers associated to the given type and URI.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_list(C::mpd_conn(), Type::string(), Uri::string()) ->
+-spec sticker_list(C::mpd_conn(), Type::string(), Uri::string_or_filter()) ->
 				[{atom(), string()}] | {error, any_error()}.
 sticker_list(C=#mpd_conn{}, Type, Uri) ->
-    parse_stickers_line(command(C, "sticker list", [Type, Uri])).
+    parse_stickers_line(command(C, "sticker list",
+                                [Type, sticker_uri(Type, Uri)])).
 
 %%-------------------------------------------------------------------
 %% @doc
 %% Get value of specific sticker by Type, URI and Name.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_get(C::mpd_conn(), Type::string(), Uri::string(),
+-spec sticker_get(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
 			Name::string()) -> string() | {error, any_error()}.
 sticker_get(C=#mpd_conn{}, Type, Uri, Name) ->
     pass_errors(
-        parse_stickers_line(command(C, "sticker get", [Type, Uri, Name])),
+        parse_stickers_line(command(C, "sticker get",
+                                    [Type, sticker_uri(Type, Uri), Name])),
         fun([{_Key, Val}]) -> Val end
     ).
 
@@ -1385,10 +1395,11 @@ sticker_get(C=#mpd_conn{}, Type, Uri, Name) ->
 %% associated key-value pairs as parsed from the stickers. 
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_find(C::mpd_conn(), Type::string(), Uri::string(),
+-spec sticker_find(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
 	Name::string()) -> [[{atom(), string()}]] | {error, any_error()}.
 sticker_find(C=#mpd_conn{}, Type, Uri, Name) ->
-    parse_stickers(command(C, "sticker find", [Type, Uri, Name])).
+    parse_stickers(command(C, "sticker find",
+                           [Type, sticker_uri(Type, Uri), Name])).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -1397,7 +1408,7 @@ sticker_find(C=#mpd_conn{}, Type, Uri, Name) ->
 %% ordering and pagination capabilities.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_find(C::mpd_conn(), Type::string(), Uri::string(),
+-spec sticker_find(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
 		Name::string(), Op::sticker_op(), CompareValue::string(),
 		Options::[window_option() | sticker_sort_option()]) ->
 		[[{atom(), string()}]] | {error, any_error()}.
@@ -1408,29 +1419,32 @@ sticker_find(C=#mpd_conn{}, Type, Uri, Name, Op, CompareValue, Options) ->
         str_lt -> "<";
         _Other -> atom_to_list(Op) % eq, lt, gt, contains, starts_with
     end,
-    parse_stickers(command(C, "sticker find", [Type, Uri, Name], ?TIMEOUT,
+    parse_stickers(command(C, "sticker find",
+        [Type, sticker_uri(Type, Uri), Name], ?TIMEOUT,
         [" ", OpString, " ", escape_arg(CompareValue),
-         sort_window_options_to_string(Options)])).
+        sort_window_options_to_string(Options)])).
 
 %%-------------------------------------------------------------------
 %% @doc
 %% Delete specific sticker by Type, URI and Name.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string(),
+-spec sticker_delete(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
 				Name::string()) -> ok | {error, any_error()}.
 sticker_delete(C=#mpd_conn{}, Type, Uri, Name) ->
-    parse_none(command(C, "sticker delete", [Type, Uri, Name])).
+    parse_none(command(C, "sticker delete",
+                       [Type, sticker_uri(Type, Uri), Name])).
 
 %%-------------------------------------------------------------------
 %% @doc
 %% Assign sticker value by Type, URI and Name.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_set(C::mpd_conn(), Type::string(), Uri::string(), Name::string(),
-				Value::string()) -> ok | {error, any_error()}.
+-spec sticker_set(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
+		Name::string(), Value::string()) -> ok | {error, any_error()}.
 sticker_set(C=#mpd_conn{}, Type, Uri, Name, Value) ->
-    parse_none(command(C, "sticker set", [Type, Uri, Name, Value])).
+    parse_none(command(C, "sticker set",
+                       [Type, sticker_uri(Type, Uri), Name, Value])).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -1438,11 +1452,11 @@ sticker_set(C=#mpd_conn{}, Type, Uri, Name, Value) ->
 %% given value if absent.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_inc(C::mpd_conn(), Type::string(), Uri::string(), Name::string(),
-				Value::integer()) -> ok | {error, any_error()}.
+-spec sticker_inc(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
+		Name::string(), Value::integer()) -> ok | {error, any_error()}.
 sticker_inc(C=#mpd_conn{}, Type, Uri, Name, Value) ->
-    parse_none(command(C, "sticker inc",
-                       [Type, Uri, Name, integer_to_list(Value)])).
+    parse_none(command(C, "sticker inc", [Type, sticker_uri(Type, Uri),
+                                          Name, integer_to_list(Value)])).
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -1459,11 +1473,11 @@ sticker_inc(C=#mpd_conn{}, Type, Uri, Name, Value) ->
 %% using sticker_dec.
 %% @end
 %%-------------------------------------------------------------------
--spec sticker_dec(C::mpd_conn(), Type::string(), Uri::string(), Name::string(),
-				Value::integer()) -> ok | {error, any_error()}.
+-spec sticker_dec(C::mpd_conn(), Type::string(), Uri::string_or_filter(),
+		Name::string(), Value::integer()) -> ok | {error, any_error()}.
 sticker_dec(C=#mpd_conn{}, Type, Uri, Name, Value) ->
-    parse_none(command(C, "sticker dec",
-                       [Type, Uri, Name, integer_to_list(Value)])).
+    parse_none(command(C, "sticker dec", [Type, sticker_uri(Type, Uri),
+                                          Name, integer_to_list(Value)])).
 
 
 %%===================================================================
@@ -1984,3 +1998,6 @@ sort_window_options_to_string(Options) ->
          Type      -> io_lib:format(" sort \"~s\"~s",
                                     [escape_quotes(atom_to_list(Type)), LS])
     end.
+
+sticker_uri("filter",   Uri) -> ex_parse(Uri);
+sticker_uri(_OtherType, Uri) -> Uri.

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -40,7 +40,8 @@
 
 %% Stickers
 -export([sticker_delete/3, sticker_delete/4, sticker_list/3, sticker_get/4,
-         sticker_find/4, sticker_find/7, sticker_set/5]).
+         sticker_find/4, sticker_find/7, sticker_set/5, sticker_inc/5,
+         sticker_dec/5]).
 
 %% Connection settings
 -export([close/1, kill/1, password/2, ping/1]).
@@ -1430,6 +1431,39 @@ sticker_delete(C=#mpd_conn{}, Type, Uri, Name) ->
 				Value::string()) -> ok | {error, any_error()}.
 sticker_set(C=#mpd_conn{}, Type, Uri, Name, Value) ->
     parse_none(command(C, "sticker set", [Type, Uri, Name, Value])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Increment sticker value by given value, creating it with the
+%% given value if absent.
+%% @end
+%%-------------------------------------------------------------------
+-spec sticker_inc(C::mpd_conn(), Type::string(), Uri::string(), Name::string(),
+				Value::integer()) -> ok | {error, any_error()}.
+sticker_inc(C=#mpd_conn{}, Type, Uri, Name, Value) ->
+    parse_none(command(C, "sticker inc",
+                       [Type, Uri, Name, integer_to_list(Value)])).
+
+%%-------------------------------------------------------------------
+%% @doc
+%% Decrement sticker value by given value if it already exists.
+%% If it does not exist yet, create a sticker with the given value.
+%%
+%% Note that this means the function is not really “inverse” of
+%% sticker_inc in any way: sticker_dec after sticker_inc does not
+%% delete stickers if their value reaches 0. sticker_inc and
+%% sticker_dec behave equally in event that a sticker does not
+%% exist yet, both causing a new sticker with the given value to be
+%% created. In many cases, a more consistent behaviour may be
+%% obtained by calling sticker_inc with a negative value in favor of
+%% using sticker_dec.
+%% @end
+%%-------------------------------------------------------------------
+-spec sticker_dec(C::mpd_conn(), Type::string(), Uri::string(), Name::string(),
+				Value::integer()) -> ok | {error, any_error()}.
+sticker_dec(C=#mpd_conn{}, Type, Uri, Name, Value) ->
+    parse_none(command(C, "sticker dec",
+                       [Type, Uri, Name, integer_to_list(Value)])).
 
 
 %%===================================================================

--- a/src/erlmpd.erl
+++ b/src/erlmpd.erl
@@ -154,7 +154,7 @@
 %%                        <td>Tests for lexicographical lower than</td></tr>
 %% </tbody></table>
 
--type window_option()       :: {window, Start::integer(), End::integer()}.
+-type window_option()       :: {window, {Start::integer(), End::integer()}}.
 %% Certain MPD commands accept sort and window options to enforce a given
 %% output ordering for the results or that only a subset of the results is
 %% returned. When a command accepts this type as input, the empty list []
@@ -1928,7 +1928,7 @@ ex_and(Expr)                 -> ["(", lists:join(" AND ", Expr), ")"].
 sort_window_options_to_string(Options) ->
     LS = case proplists:get_value(window, Options) of
          undefined    -> "";
-         {Start, End} -> io_lib:format(" window \"~w:~w\"", Start, End)
+         {Start, End} -> io_lib:format(" window \"~w:~w\"", [Start, End])
          end,
     case proplists:get_value(sort, Options) of
          undefined -> LS;

--- a/support/include.mk
+++ b/support/include.mk
@@ -43,6 +43,6 @@ $(EBIN_DIR)/%.$(EMULATOR): %.erl
 	$(ERLC) $(ERLC_FLAGS) -o . $<
 
 $(DOC_DIR)/%.html: %.erl
-	$(ERL) -noshell -run edoc file $< -run init stop
+	$(ERL) -noshell -run edoc files $< -run init stop
 	@mkdir -p $(DOC_DIR)
 	mv *.html $(DOC_DIR)

--- a/support/include.mk
+++ b/support/include.mk
@@ -45,4 +45,5 @@ $(EBIN_DIR)/%.$(EMULATOR): %.erl
 $(DOC_DIR)/%.html: %.erl
 	$(ERL) -noshell -run edoc files $< -run init stop
 	@mkdir -p $(DOC_DIR)
-	mv *.html $(DOC_DIR)
+	-rm edoc-info
+	mv *.html *.css *.png $(DOC_DIR)


### PR DESCRIPTION
Hello,

while there is no public code for my client yet (it's a slow work-in-progress), I figured I could share some of the patches that I have created for the `erlmpd` library. It is currently an assorted set of changes that I found useful while working on  my client.

I don't mind maintaining an own fork, but in case some of the patches also look useful to you, feel free to include them into the upstream or provide comments. In case a certain subset looks interesting to you, I can also split up this PR as needed.

The patches address the following topics:

 * The first commits reduce warnings and enable rebar3 support to make including the library as a dependency easier
 * I enabled the sticker code and worked on parsing some of the sticker command's outputs. In the most recent changes I also gave the sticker operations dedicated functions (this makes declaring the types properly easier and since the code had been commented-out before I figured the API needed not to be stable yet :smile:)
 * find() newly supports an advanced query syntax. I included a patch to build this syntax with all the correct quoting and aligned to the MPD protocol specification.
 * I had some fun with idle/noidle interactions and proposed a preliminary workaround for the issue. It may require some additional patch to resolve it completely, but I couldn't figure out how to do it completely just yet hence I suggest a one-line workaround :smile:

Thanks in advance and Kind regards
Linux-Fan (@m7a)